### PR TITLE
Correct timeout and error handling for AMT connections

### DIFF
--- a/wry/wsmanResource.py
+++ b/wry/wsmanResource.py
@@ -18,6 +18,7 @@ import requests
 import WryDict
 from time import sleep
 
+
 class wsmanResource(object):
     '''
     Class to represent a resource on a wsman compatible server
@@ -75,7 +76,7 @@ class wsmanResource(object):
                     print "Connecting to %s" % (self.target,)
                 resp = requests.post(
                     self.target,
-                    timeout = (2, 1),
+                    timeout = (0.1, 5),
                     headers = {'content-type': 'application/soap+xml;charset=UTF-8'},
                     auth = requests.auth.HTTPDigestAuth(self.username, self.password),
                     data = doc,
@@ -87,12 +88,10 @@ class wsmanResource(object):
                     print "===================="
                 resp.raise_for_status()
                 return WryDict.WryDict.from_xml(resp.content)
-            except requests.exceptions.ConnectTimeout:
+            except:
                 if self.debug:
                     print("Failed, retrying")
                 sleep(wsmanData.CONNECT_DELAY)
-            except:
-                raise
 
     def get(self, setting = '', **kwargs):
         '''


### PR DESCRIPTION
Timeouts were non-optimal and error handling didn't take AMT's unreliability into account.

We now only wait 0.1 sec for connection but once connected wait 5 secs for work/data to complete.

If a connection fails for timeout or any other reason the connection should be retried as AMT often (more than 75% of the time) fails to accept the first connection. (Previously retry only happened on a timeout).